### PR TITLE
Develop

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,40 +1,19 @@
 # Description
 
-Please include a summary of the change and which issue is fixed. 
+Please include a summary of the changes and which issues are fixed. 
 Please also include relevant motivation and context. 
-List any dependencies that are required for this change.
+List any dependencies that are required for this change,
+indicating whether this is a major (breaking), minor, or patch change.
 
-Fixes # (issue)
-
-## Type of change
-
-Please delete options that are not relevant.
-
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] This change requires a documentation update
-
-# How Has This Been Tested?
-
-Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-
-- [ ] Test A
-- [ ] Test B
-
-**Test Configuration**:
-* Firmware version:
-* Hardware:
-* Toolchain:
-* SDK:
+Fixes #(issue no.)
+Closes #(issue no.)
 
 # Checklist:
 
-- [ ] My code follows the style guidelines of this project
-- [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
-- [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests pass locally with my changes
-- [ ] Any dependent changes have been merged and published in downstream modules
+- [ ] The package builds on my OS without issues (please add workstation details)
+- [ ] My changes generate no new warnings
+- [ ] My code follows the style guidelines of this project
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation (.R, NEWS.md)
+- [ ] I have bumped the version by the appropriate increment in the DESCRIPTION file (major, minor, patch)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 on:
-  push:
-    branches: 
+  pull_request:
+    branches:
       - master
       
 name: Binary creation
@@ -71,63 +71,3 @@ jobs:
           file.copy(binary, "build")
         shell: Rscript {0}
     
-      - name: Save binary artifact
-        uses: actions/upload-artifact@v1
-        with:
-          name: ${{ matrix.config.asset_name }}
-          path: build/
-          
-  release:
-    name: Bump version and release
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout one
-        uses: actions/checkout@master
-        with:
-          fetch-depth: '0'
-      - name: Bump version and push tag
-        id: newtag
-        uses: anothrNick/github-tag-action@1.17.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WITH_V: true
-          DEFAULT_BUMP: patch
-      - name: Checkout two
-        uses: actions/checkout@v2
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.newtag.outputs.tag }}
-          release_name: Release ${{ steps.newtag.outputs.tag }}
-          draft: false
-          prerelease: false
-          
-      - name: Download binaries
-        uses: actions/download-artifact@v2
-        
-      - name: Display structure of downloaded files
-        run: ls -R
-
-      - name: Zip up
-        uses: montudor/action-zip@v0.1.0
-        with:
-          args: zip -qq -r iheiddown_AllOS.zip . -i ./macOS/* ./winOS/*
-
-      - name: Display structure of downloaded files again
-        run: ls -R
-
-      - name: Upload binary
-        id: upload-binary 
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: iheiddown_AllOS.zip
-          asset_name: iheiddown_AllOS.zip
-          asset_content_type: application/zip
-          

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,7 @@
 Package: iheiddown
-Title: A RMarkdown class for IHEID dissertations
-Version: 0.3.0
+Title: A RMarkdown class for IHEID documents
+Date: 2020-07-06
+Version: 0.4.0
 Authors@R: 
     c(person(given = "James",
            family = "Hollway",
@@ -8,8 +9,8 @@ Authors@R:
            email = "james.hollway@graduateinstitute.ch",
            comment = c(ORCID = "0000-0002-8361-9647")),
       person("Nina", "Schlager", role = "ctb"))
-Description: This package supports writing theses according to
-    the Graduate Institute of International and Development Studies 
+Description: This package supports writing dissertations, theses, and syllabi
+    according to the Graduate Institute of International and Development Studies 
     regulations.
 License: MIT
 Imports: bookdown, tidyverse, roxygen2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# iheiddown 0.4.0
+
+* Differentiated between PhD theses and masters dissertations in front pages
+  * Breaking change: Note that you will now need to specify phd: true or phd: false in metadata
+* Added supervisor and second reader information to metadata, appear on first page
+  * Added external examiner information to metadata, appears on first page for PhDs
+* Updates to pull request template
+
 # iheiddown 0.3.0
 
 * Added `syllabus_pdf()` function

--- a/inst/rmarkdown/templates/thesis/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/thesis/skeleton/skeleton.Rmd
@@ -10,7 +10,7 @@ title: |
 firstnames: Author
 lastnames: Name
 thesisno: 12345
-degree: Doctor of Philosophy
+phd: true # Or: false for Masters
 department: Your Department
 degreedate: June 2020
 # This is the YAML (YAML Ain't Markup Language) header that includes 

--- a/inst/rmarkdown/templates/thesis/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/thesis/skeleton/skeleton.Rmd
@@ -13,6 +13,9 @@ thesisno: 12345
 phd: true # Or: false for Masters
 department: Your Department
 degreedate: June 2020
+supervisor: Minerva McGonagall
+secondreader: Horace Slughorn
+examiner: Olympe Maxime # only required if PhD; otherwise delete or comment out
 # This is the YAML (YAML Ain't Markup Language) header that includes 
 # metadata used to produce the document. 
 # Be careful with spacing in this header!

--- a/inst/rmarkdown/templates/thesis_pdf/resources/template.tex
+++ b/inst/rmarkdown/templates/thesis_pdf/resources/template.tex
@@ -317,6 +317,13 @@ $endif$
 \sffamily{Thesis No. $thesisno$}
 
 \vspace*{1cm}
+\sffamily\textbf{Supervisor: $supervisor$}\\
+\sffamily\textbf{Second Reader: $secondreader$}
+$if(phd)$
+\\\sffamily\textbf{External Examiner: $examiner$}
+$endif$
+
+\vspace*{1cm}
 \sffamily\textbf{Geneva}\\
 \sffamily\textbf{\the\year}
 

--- a/inst/rmarkdown/templates/thesis_pdf/resources/template.tex
+++ b/inst/rmarkdown/templates/thesis_pdf/resources/template.tex
@@ -324,6 +324,7 @@ $endif$
 \end{titlepage}
 
 % TITLEPAGE 2 (empty page)
+$if(phd)$
 \newpage\null\thispagestyle{empty}\newpage
 
 % TITLEPAGE 3
@@ -366,6 +367,7 @@ GRADUATE INSTITUTE OF INTERNATIONAL AND DEVELOPMENT STUDIES
 
 \thispagestyle{firstpages}
 \end{titlepage}
+$endif$
 
 % TITLEPAGE 6
 \begin{titlepage}


### PR DESCRIPTION
# Description

* Differentiated between PhD theses and masters dissertations in front pages
  * Breaking change: Note that you will now need to specify phd: true or phd: false in metadata
* Added supervisor and second reader information to metadata, appear on first page
  * Added external examiner information to metadata, appears on first page for PhDs
* Updates to pull request template