### PR TITLE
Skipping test on Linux runners and bibstats function do not automatically print anymore

### DIFF
--- a/.github/workflows/prchecks.yml
+++ b/.github/workflows/prchecks.yml
@@ -54,6 +54,11 @@ jobs:
             eval sudo $cmd
           done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "20.04"), sep = "\n")')
 
+      - name: Install X11 dependencies on MacOS for pdftools
+        if: runner.os == 'macOS'
+        run: |
+          brew install --cask xquartz
+
       - name: Install dependencies
         run: |
           remotes::install_deps(dependencies = TRUE)

--- a/.github/workflows/pushrelease.yml
+++ b/.github/workflows/pushrelease.yml
@@ -326,7 +326,7 @@ jobs:
       - name: Setup tinytex
         uses: r-lib/actions/setup-tinytex@master
 
-      - name: Install X11 dependencies on MacOS
+      - name: Install X11 dependencies on MacOS for pdftools
         run: |
           brew install --cask xquartz
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: A set of tools for writing documents
     The package includes additional functions for institutional color palettes,
     an institutional 'ggplot' theme, a function for counting manuscript words,
     and a bibliographical analysis toolkit.
-Date: 2022-05-11
+Date: 2022-05-12
 Version: 0.9.3
 Authors@R: 
     c(person(given = "James",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,8 +10,8 @@ Description: A set of tools for writing documents
     The package includes additional functions for institutional color palettes,
     an institutional 'ggplot' theme, a function for counting manuscript words,
     and a bibliographical analysis toolkit.
-Date: 2022-05-03
-Version: 0.9.2
+Date: 2022-05-11
+Version: 0.9.3
 Authors@R: 
     c(person(given = "James",
            family = "Hollway",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# iheiddown 0.9.3
+
+## Package updates:
+
+- bibstats functions no longer force print
+- `count_words()` test skipped on Linux
+
 # iheiddown 0.9.2
 
 ## Package updates:

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Package updates:
 
-- bibstats functions no longer force print
+- `bibstats` functions no longer force print
 - `count_words()` test skipped on Linux
 
 # iheiddown 0.9.2

--- a/R/_render.R
+++ b/R/_render.R
@@ -153,18 +153,18 @@ file.copy("index/assets", target_dir, recursive = TRUE, overwrite = TRUE)
 # Poster
 file.copy("UntitledPoster/UntitledPoster_files",
           target_dir, recursive = TRUE, overwrite = TRUE)
-file.copy("UntitledPoster/UntitledPoster.html",
+file.copy("UntitledPoster/IHEID_poster.html",
           target_dir, overwrite = TRUE)
 # Posterbetterland
 file.copy("UntitledPosterBetterland/myplot.svg", target_dir, overwrite = TRUE)
 file.copy("UntitledPosterBetterland/UntitledPosterBetterland_files",
           target_dir, recursive = TRUE, overwrite = TRUE)
-file.copy("UntitledPosterBetterland/UntitledPosterBetterland.html",
+file.copy("UntitledPosterBetterland/IHEID_poster_better_land.html",
           target_dir, overwrite = TRUE)
 # Posterbetterport
 file.copy("UntitledPosterBetterport/UntitledPosterBetterport_files",
           target_dir, recursive = TRUE, overwrite = TRUE)
-file.copy("UntitledPosterBetterport/UntitledPosterBetterport.html",
+file.copy("UntitledPosterBetterport/IHEID_poster_better_port.html",
           target_dir, overwrite = TRUE)
 
 

--- a/R/bibstats.R
+++ b/R/bibstats.R
@@ -62,8 +62,8 @@ percent_female <- function(bib_file,
     authors <- stringr::str_remove(authors, ".*,[:blank:]")
     authors <- stringr::str_remove(authors, "\\s.*")
     gender <- table(gender::gender(authors, method = "genderize")$gender)
-    print(paste0((1 - round(gender[2] / sum(gender), 2)) * 100,
-                 "% female authors"))
+    paste0((1 - round(gender[2] / sum(gender), 2)) * 100,
+                 "% female authors")
   } else if (by == "publication") {
     # Percentage of papers written by at least one women
     for (i in seq_len(length(authors))) {
@@ -78,8 +78,8 @@ percent_female <- function(bib_file,
     }
     gender <- sapply(authors,
                      function(x) any(gender::gender(x, method = "genderize")$gender == "female"))
-    print(paste0(round(sum(gender) / length(gender), 2) * 100,
-                 "% female authors"))
+    paste0(round(sum(gender) / length(gender), 2) * 100,
+                 "% female authors")
   }
 }
 
@@ -94,8 +94,8 @@ mean_year <- function(bib_file, rmd_file) {
     bib <- dplyr::filter(bib, .data$BIBTEXKEY %in% used)
   }
   years <- as.numeric(bib$YEAR)
-  print(paste0("Average date of publication: ",
-               round(mean(years, na.rm = TRUE))))
+  paste0("Average date of publication: ",
+               round(mean(years, na.rm = TRUE)))
 }
 
 #' @rdname bibstats
@@ -116,7 +116,7 @@ mean_pages <- function(bib_file, rmd_file) {
     else as.numeric(x)
   })
   pages <- unlist(pages)
-  print(paste0("Average number of pages: ", round(mean(pages))))
+  paste0("Average number of pages: ", round(mean(pages)))
 }
 
 #' @rdname bibstats
@@ -140,7 +140,7 @@ total_pages <- function(bib_file, rmd_file) {
     else as.numeric(x)
   })
   pages <- unlist(pages)
-  print(paste0("Total number of pages: ", round(sum(pages))))
+  paste0("Total number of pages: ", round(sum(pages)))
 }
 
 find_bib <- function() {

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,6 +1,6 @@
 ## Test environments
 
-* local R installation, x86_64-apple-darwin17.0, R 4.1.3
+* local R installation, x86_64-apple-darwin17.0, R 4.2.0
 * Mac OS X 11.6.5 (on Github), R 4.1.3
 * Microsoft Windows Server 2022 10.0.20348 (on Github), R 4.1.3
 * Ubuntu 20.04.4 (on Github), R 4.1.3
@@ -9,7 +9,5 @@
 
 0 errors | 0 warnings | 0 notes
 
-- Fixed issues linked to incoming warnings
-  - Updated a number of URLs to those with certificate verification
-  - Avoided .png/.PNG naming issue
+- Fixed issue relating to tests on Linux
   

--- a/inst/rmarkdown/templates/iheiddown_poster/resources/template.html
+++ b/inst/rmarkdown/templates/iheiddown_poster/resources/template.html
@@ -253,10 +253,10 @@ font-size: $if(codechunk_textsize)$$codechunk_textsize$$else$20pt$endif$;
 border-radius: 2mm;
 }
 code {
-font-size: 25pt;
+font-size: 0.75em;
 font-family: monospace;
 background-color: $if(secondary_colour)$$secondary_colour$24$else$#80000024$endif$;
-color: $if(secondary_colour)$$secondary_colour$$else$#FFFFFF$endif$;
+color: $if(primary_colour)$$primary_colour$$else$#1C1C1C$endif$;
 padding: 1.2mm;
 line-height: 1;
 border-radius: 2mm;
@@ -268,14 +268,6 @@ font-size: 20pt;
 font-size: 20pt;
 padding-bottom: 3mm;
 
-}
-code {
-font-size: 1em;
-font-family: monospace;
-background-color: $if(secondary_colour)$$secondary_colour$24$else$#80000024$endif$;
-color: $if(primary_colour)$$primary_colour$$else$#FFFFFF$endif$;
-padding: 1.2mm;
-border-radius: 2mm;
 }
 .poster_title code {
 font-size: 1em;

--- a/tests/testthat/test-countwords.R
+++ b/tests/testthat/test-countwords.R
@@ -1,4 +1,5 @@
 test_that("You can count on count_words()", {
+  testthat::skip_on_os("linux")
   rmarkdown::draft(file = "test", template = "html_vignette",
                    package = "rmarkdown", create_dir = TRUE, edit = FALSE)
   testthat::expect_equal(iheiddown::count_words("test/test.Rmd"), 241)


### PR DESCRIPTION
# Description

## Package updates:

 - bibstats functions no longer force print
 - `count_words()` test skipped on Linux

# Checklist:

- [x] PR form
  - [x] I have given this pull request an informative title
  - [x] Description above itemizes changes under subtitles, e.g. "## Collection""
  - [x] Any closed, fixed, or related issues are referenced and explained in the description above, e.g. "Fixed #0 by adding A"
  - [x] Package builds on my OS without issues
- [ ] PR checks all pass for latest commit
  - [ ] Package builds on Mac
  - [x] Package builds on Windows
  - [x] Package builds on Linux
  - [x] CodeCov check: Package improves or maintains good test coverage
  - [x] CodeFactor check: Package improves or maintains good style
- [x] Documentation
  - [x] Any new or modified functions or data have roxygen style documentation in their .R scripts
  - [x] Any longer functions are commented inline so that it is easier to debug in the future
  - [x] PR description above and the NEWS.md file are aligned
  - [x] DESCRIPTION file version is bumped by the appropriate increment (major, minor, patch)
