### PR TITLE
Added xquartz dependency on mac to build job on the pushrelease workflow

### DIFF
--- a/.github/workflows/pushrelease.yml
+++ b/.github/workflows/pushrelease.yml
@@ -63,6 +63,11 @@ jobs:
             eval sudo $cmd
           done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "20.04"), sep = "\n")')
 
+      - name: Install X11 dependencies on MacOS for pdftools
+        if: runner.os == 'macOS'
+        run: |
+          brew install --cask xquartz
+
       - name: Install dependencies
         run: |
           remotes::install_deps(dependencies = TRUE)


### PR DESCRIPTION
# Description

- Added `xquartz` dependency on mac to build job on the `pushrelease` workflow

# Checklist:

- [x] PR form
  - [x] I have given this pull request an informative title
  - [x] Description above itemizes changes under subtitles, e.g. "## Collection""
  - [x] Any closed, fixed, or related issues are referenced and explained in the description above, e.g. "Fixed #0 by adding A"
  - [x] Package builds on my OS without issues
- [x] PR checks all pass for latest commit
  - [x] Package builds on Mac
  - [x] Package builds on Windows
  - [x] Package builds on Linux
  - [x] CodeCov check: Package improves or maintains good test coverage
  - [x] CodeFactor check: Package improves or maintains good style
- [x] Documentation
  - [x] Any new or modified functions or data have roxygen style documentation in their .R scripts
  - [x] Any longer functions are commented inline so that it is easier to debug in the future
  - [x] PR description above and the NEWS.md file are aligned
  - [x] DESCRIPTION file version is bumped by the appropriate increment (major, minor, patch)
